### PR TITLE
change hardcoded stack name to configurable

### DIFF
--- a/{{cookiecutter.github_repo_name}}/terraform/environments/wordpress/{{ cookiecutter.wordpress_namespace }}/terragrunt.hcl
+++ b/{{cookiecutter.github_repo_name}}/terraform/environments/wordpress/{{ cookiecutter.wordpress_namespace }}/terragrunt.hcl
@@ -49,15 +49,15 @@ locals {
 
 dependencies {
   paths = [
-    "../../../stacks/service/vpc",
-    "../../../stacks/service/kubernetes",
-    "../../../stacks/service/mysql",
-    "../../../stacks/service/redis",
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/vpc",
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/kubernetes",
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/mysql",
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/redis",
     ]
 }
 
 dependency "vpc" {
-  config_path = "../../../stacks/service/vpc"
+  config_path = "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/vpc"
 
   # Configure mock outputs for the `validate` and `init` commands that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
@@ -71,7 +71,7 @@ dependency "vpc" {
 }
 
 dependency "kubernetes" {
-  config_path = "../../../stacks/service/kubernetes"
+  config_path = "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/kubernetes"
 
   # Configure mock outputs for the `validate` and `init` commands that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
@@ -97,7 +97,7 @@ dependency "kubernetes" {
 }
 
 dependency "mysql" {
-  config_path = "../../../stacks/service/mysql"
+  config_path = "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/mysql"
 
   # Configure mock outputs for the `validate` and `init` commands that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.

--- a/{{cookiecutter.github_repo_name}}/terraform/environments/{{cookiecutter.environment_name}}/redis/terragrunt.hcl
+++ b/{{cookiecutter.github_repo_name}}/terraform/environments/{{cookiecutter.environment_name}}/redis/terragrunt.hcl
@@ -26,15 +26,15 @@ locals {
 
 dependencies {
   paths = [
-    "../../../stacks/service/vpc",
-    "../../../stacks/service/kubernetes",
-    "../../../stacks/service/redis",
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/vpc",
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/kubernetes",
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/redis",
     "../vpc",
     ]
 }
 
 dependency "vpc" {
-  config_path = "../../../stacks/service/vpc"
+  config_path = "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/vpc"
 
   # Configure mock outputs for the `validate` and `init` commands that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
@@ -48,7 +48,7 @@ dependency "vpc" {
 }
 
 dependency "kubernetes" {
-  config_path = "../../../stacks/service/kubernetes"
+  config_path = "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/kubernetes"
 
   # Configure mock outputs for the `validate` and `init` commands that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
@@ -74,7 +74,7 @@ dependency "kubernetes" {
 }
 
 dependency "redis" {
-  config_path = "../../../stacks/service/redis"
+  config_path = "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/redis"
 
   # Configure mock outputs for the `validate` and `init` commands that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.

--- a/{{cookiecutter.github_repo_name}}/terraform/environments/{{cookiecutter.environment_name}}/ses/terragrunt.hcl
+++ b/{{cookiecutter.github_repo_name}}/terraform/environments/{{cookiecutter.environment_name}}/ses/terragrunt.hcl
@@ -24,12 +24,12 @@ locals {
 
 dependencies {
   paths = [
-    "../../../stacks/service/vpc"
+    "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/vpc"
     ]
 }
 
 dependency "vpc" {
-  config_path = "../../../stacks/service/vpc"
+  config_path = "../../../stacks/{{ cookiecutter.global_platform_shared_resource_identifier }}/vpc"
 
   # Configure mock outputs for the `validate` and `init` commands that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #50 

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
There were a few places where the stack name was hardcoded in a path that needed to be changed to use the config value sent via the make.sh script.
