### PR TITLE
Modify eks-auth map_roles to use rolearn instead of userarn

### DIFF
--- a/{{cookiecutter.github_repo_name}}/terraform/stacks/modules/kubernetes/variables.tf
+++ b/{{cookiecutter.github_repo_name}}/terraform/stacks/modules/kubernetes/variables.tf
@@ -66,7 +66,7 @@ variable "map_users" {
 variable "map_roles" {
   description = "Additional IAM roles to add to the aws-auth configmap."
   type = list(object({
-    userarn  = string
+    rolearn  = string
     username = string
     groups   = list(string)
   }))


### PR DESCRIPTION
According to [https://registry.terraform.io/modules/aidanmelen/eks-auth/aws/1.0.0], rolearn should be used instead

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] Bug fix

### Resolves
- Fixes #[60]


### Describe Changes
<!-- Describe your changes in detail, if applicable. -->

This change simply modifies the `variable "map_roles"` inside the `variables.tf `file to use **_rolearn_** instead of **_userarn_**.

