### PR TITLE
Bug fix: Unexpected Jinja TemplateSyntaxError in kubernetes.tf for Missing Conditional Closing Tags

### DIFF
--- a/{{cookiecutter.github_repo_name}}/terraform/environments/modules/mysql/kubernetes.tf
+++ b/{{cookiecutter.github_repo_name}}/terraform/environments/modules/mysql/kubernetes.tf
@@ -81,6 +81,7 @@ resource "kubernetes_secret" "discovery" {
     MYSQL_PORT               = data.kubernetes_secret.mysql_root.data.MYSQL_PORT
   }
 }
+{% endif %}
 
 resource "random_password" "mysql_ecommerce" {
   length           = 16


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
Fix the unexpected Jinja TemplateSyntaxError in kubernetes.tf for Missing Conditional Closing Tags when you execute cookiecutter.

Error:
```[INFO]: Open edX devops Cookiecutter 
Traceback (most recent call last): 
  ...
  File "terraform/environments/modules/mysql/kubernetes.tf", line 204, in template
jinja2.exceptions.TemplateSyntaxError: Unexpected end of template. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
  File "terraform/environments/modules/mysql/kubernetes.tf", line 204
    }{% endif %}```
